### PR TITLE
More edits by Grad School :)

### DIFF
--- a/uathesis.cls
+++ b/uathesis.cls
@@ -51,6 +51,7 @@
 \usepackage[nonumberlist,xindy,toc,nopostdot,nogroupskip]{glossaries}
 \usepackage{glossary-superragged}
 \setglossarystyle{superragged}
+\setlength{\glsdescwidth}{0.69\textwidth}
 
 \renewcommand{\glossaryname}{LIST OF ABBREVIATIONS AND SYMBOLS}
 
@@ -268,7 +269,9 @@
     \begin{center}
       \MakeTextUppercase{ \textbf{ \@chapapp\space \thechapter } }
       \linebreak
+      \begin{spacing}{1}
       \MakeTextUppercase{ \textbf{ ##1 } }
+      \end{spacing}
     \end{center}
   }
   


### PR DESCRIPTION
I guess they like to review everything on the guideline. So here is two more.

1) List of Abbreviations and Symbols: Abbreviation definitions that are longer than one line should be single spaced internally with a blank line between entries (ie. CORBA, DelTa, Motif, XSLT) 

2) Chapter titles in the body of the paper: When they are longer than one line, they should be single spaced internally while leaving a blank line between the heading and the content of the chapter. 